### PR TITLE
multi_image: Flashing of multi core

### DIFF
--- a/cmake/partition_manager.cmake
+++ b/cmake/partition_manager.cmake
@@ -244,12 +244,14 @@ if (is_dynamic_partition_in_domain)  # We are being built as sub image
     "set(PM_DOMAINS_${domain}_IMAGES ${prefixed_images})\n"
     )
 
-  set_property(
-    TARGET         zephyr_property_target
-    APPEND_STRING
-    PROPERTY       shared_vars
-    "set(PM_DOMAINS_${domain}_HEX_FILE ${PROJECT_BINARY_DIR}/merged_${domain}.hex)\n"
-    )
+  if(NOT ("${IMAGE_NAME}" STREQUAL "${PM_${domain}_DYNAMIC_PARTITION}_"))
+    set_property(
+      TARGET         zephyr_property_target
+      APPEND_STRING
+      PROPERTY       shared_vars
+      "set(PM_DOMAINS_${domain}_HEX_FILE ${PROJECT_BINARY_DIR}/merged_${domain}.hex)\n"
+      )
+  endif()
 else()
   # This is the root image, generate the global pm_config.h files
   list(REMOVE_DUPLICATES PM_DOMAINS)

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -32,5 +32,5 @@ if (CONFIG_HCI_RPMSG)
     message(FATAL_ERROR "Board ${BOARD} not supported for including hci_rpmsg as child image")
   endif()
 
-  add_child_image(hci_rpmsg ${NRF_DIR}/../zephyr/samples/bluetooth/hci_rpmsg)
+  create_domain_image(hci_rpmsg ${ZEPHYR_BASE}/samples/bluetooth/hci_rpmsg)
 endif()


### PR DESCRIPTION
This commit introduces the possibility of adding flashing of other
cores.

A sub-images for its own domain can be added and this image will not be
merged into the parent image. Instead an additional flash target for
the domain / core is defined.
This flash target is added as a dependency to the flash target of the
parent to ensure proper flashing of all images.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>