### PR TITLE
cmake: Add partition manager report as dependency to rom_report target.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@
 set(NRF_DIR ${CMAKE_CURRENT_LIST_DIR} CACHE PATH "NCS root directory")
 
 include(cmake/multi_image.cmake)
+include(cmake/reports.cmake)
 
 zephyr_include_directories(include)
 

--- a/cmake/reports.cmake
+++ b/cmake/reports.cmake
@@ -4,12 +4,16 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-add_custom_command(
-  TARGET rom_report
-  POST_BUILD
+add_custom_target(
+  partition_manager_report
   COMMAND
   ${PYTHON_EXECUTABLE}
   ${ZEPHYR_BASE}/../nrf/scripts/partition_manager_report.py
   --input ${CMAKE_BINARY_DIR}/partitions.yml
   "$<$<NOT:$<TARGET_EXISTS:partition_manager>>:--quiet>"
   )
+
+set_property(TARGET zephyr_property_target
+             APPEND PROPERTY rom_report_DEPENDENCIES
+             partition_manager_report
+	     )


### PR DESCRIPTION

Comments on PR #1741
and https://github.com/NordicPlayground/fw-nrfconnect-zephyr/pull/260