### PR TITLE
cmake: partition manager report

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2020 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+function(get_board_without_ns_suffix board_in board_out)
+  string(REGEX REPLACE "(_?ns)$" "" board_in_without_suffix ${board_in})
+  if(NOT ${board_in} STREQUAL ${board_in_without_suffix})
+    if (NOT CONFIG_ARM_NONSECURE_FIRMWARE)
+      message(FATAL_ERROR "${board_in} is not a valid name for a board without "
+      "'CONFIG_ARM_NONSECURE_FIRMWARE' set. This because the 'ns'/'_ns' ending "
+      "indicates that the board is the non-secure variant in a TrustZone "
+      "enabled system.")
+    endif()
+    set(${board_out} ${board_in_without_suffix} PARENT_SCOPE)
+    message("Changed board to secure ${board_in_without_suffix} (NOT NS)")
+  else()
+    set(${board_out} ${board_in} PARENT_SCOPE)
+  endif()
+endfunction()

--- a/cmake/partition_manager.cmake
+++ b/cmake/partition_manager.cmake
@@ -4,12 +4,6 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-define_property(GLOBAL PROPERTY PM_IMAGES
-  BRIEF_DOCS "A list of all images that should be processed by the Partition Manager."
-  FULL_DOCS "A list of all images that should be processed by the Partition Manager.
-Each image's directory will be searched for a pm.yml, and will receive a pm_config.h header file with the result.
-Also, each image's hex file will be automatically associated with its partition.")
-
 macro(add_region)
   set(oneValueArgs NAME SIZE BASE PLACEMENT DEVICE DYNAMIC_PARTITION)
   cmake_parse_arguments(REGION "" "${oneValueArgs}" "" ${ARGN})
@@ -27,231 +21,298 @@ macro(add_region)
   endif()
 endmacro()
 
+include(${ZEPHYR_BASE}/../nrf/cmake/extensions.cmake)
+
+# Get the domain of the current board.
+# In a multi core/SoC build, each core/SoC is a domain as seen from the
+# Partition Manager. Each domain is handled individually by the Partition
+# Manager. Once the Partition Manager has solved all the domains, it creates
+# a global configuration consisting of all domain configurations.
+get_board_without_ns_suffix(${BOARD} domain)
+
+# Load static configuration if found.
+set(user_def_pm_static ${PM_STATIC_YML_FILE})
+set(nodomain_pm_static ${APPLICATION_SOURCE_DIR}/pm_static.yml)
+set(domain_pm_static ${APPLICATION_SOURCE_DIR}/pm_static_${domain}.yml)
+
+if(EXISTS "${user_def_pm_static}" AND NOT IS_DIRECTORY "${user_def_pm_static}")
+  set(static_configuration_file ${user_def_pm_static})
+elseif (EXISTS ${domain_pm_static})
+  set(static_configuration_file ${domain_pm_static})
+elseif (EXISTS ${nodomain_pm_static})
+  set(static_configuration_file ${nodomain_pm_static})
+endif()
+
+if (EXISTS ${static_configuration_file})
+  set(static_configuration --static-config ${static_configuration_file})
+endif()
+
+# Check if current image is the dynamic partition in its domain.
+# I.E. it is the only partition without a statically configured size in this
+# domain. This is equivalent to the 'app' partition in the root domain.
+#
+# The dynamic partition is specified by the parent domain (i.e. the domain
+# which creates the current domain through 'create_domain_image()'.
+if("${IMAGE_NAME}" STREQUAL "${${domain}_PM_DOMAIN_DYNAMIC_PARTITION}_")
+  set(is_dynamic_partition_in_domain TRUE)
+endif()
+
 get_property(PM_IMAGES GLOBAL PROPERTY PM_IMAGES)
-get_property(PM_SUBSYS_PREPROCESSED GLOBAL PROPERTY PM_SUBSYS_PREPROCESSED)
 
-if(EXISTS "${PM_STATIC_YML_FILE}" AND NOT IS_DIRECTORY "${PM_STATIC_YML_FILE}")
-  set(static_configuration_file ${PM_STATIC_YML_FILE})
+# This file is executed once per domain.
+#
+# It will be executed if one of the following criteria is true for the
+# current image:
+# - It's a child image, and is the dynamic partition in the domain
+# - It's the root image, and a static configuration has been provided
+# - It's the root image, and PM_IMAGES is populated.
+# - It's the root image, and other domains exist.
+# Otherwise, return here
+if (NOT (
+  (IMAGE_NAME AND is_dynamic_partition_in_domain) OR
+  (NOT IMAGE_NAME AND static_configuration) OR
+  (NOT IMAGE_NAME AND PM_IMAGES) OR
+  (NOT IMAGE_NAME AND PM_DOMAINS)
+  ))
+  return()
+endif()
+
+# Set the dynamic partition. This is the only partition which does not
+# have a statically defined size. There is only one dynamic partition per
+# domain. For the "root domain" (ie the domain of the root image) this is
+# always "app".
+if (NOT is_dynamic_partition_in_domain)
+  set(dynamic_partition "app")
 else()
-  set(static_configuration_file ${APPLICATION_SOURCE_DIR}/pm_static.yml)
+  set(dynamic_partition ${${domain}_PM_DOMAIN_DYNAMIC_PARTITION})
+  set(
+    dynamic_partition_argument
+    "--flash_primary-dynamic-partition;${dynamic_partition}"
+    )
 endif()
 
-if(PM_IMAGES OR (EXISTS ${static_configuration_file}))
-  # Partition manager is enabled because we have populated PM_IMAGES,
-  # or because the application has specified a static configuration.
-  if (EXISTS ${static_configuration_file})
-    set(static_configuration --static-config ${static_configuration_file})
-  endif()
+# Add the dynamic partition as an image partition.
+set_property(GLOBAL PROPERTY
+  ${dynamic_partition}_PM_HEX_FILE
+  ${PROJECT_BINARY_DIR}/${KERNEL_HEX_NAME}
+  )
 
-  set(generated_path zephyr/include/generated)
+set_property(GLOBAL PROPERTY
+  ${dynamic_partition}_PM_TARGET
+  ${logical_target_for_zephyr_elf}
+  )
 
-  # Add the "app" as an image partition.
-  set_property(GLOBAL PROPERTY app_PM_HEX_FILE ${PROJECT_BINARY_DIR}/${KERNEL_HEX_NAME})
-  set_property(GLOBAL PROPERTY app_PM_TARGET ${logical_target_for_zephyr_elf})
+# Prepare the input_files, header_files, and images lists
+set(generated_path zephyr/include/generated)
+foreach (image ${PM_IMAGES})
+  list(APPEND prefixed_images ${domain}:${image})
+  list(APPEND images ${image})
+  list(APPEND input_files ${CMAKE_BINARY_DIR}/${image}/${generated_path}/pm.yml)
+  list(APPEND header_files ${CMAKE_BINARY_DIR}/${image}/${generated_path}/pm_config.h)
+endforeach()
 
-  # Prepare the input_files, header_files, and images lists
-  foreach (image_name ${PM_IMAGES})
-    list(APPEND images ${image_name})
-    list(APPEND input_files ${CMAKE_BINARY_DIR}/${image_name}/${generated_path}/pm.yml)
-    list(APPEND header_files ${CMAKE_BINARY_DIR}/${image_name}/${generated_path}/pm_config.h)
-  endforeach()
+# Explicitly add the dynamic partition image
+list(APPEND prefixed_images "${domain}:${dynamic_partition}")
+list(APPEND images ${dynamic_partition})
+list(APPEND input_files ${CMAKE_BINARY_DIR}/${generated_path}/pm.yml)
+list(APPEND header_files ${CMAKE_BINARY_DIR}/${generated_path}/pm_config.h)
 
-  # Special treatmen of the app image.
-  list(APPEND images "app")
-  list(APPEND input_files ${CMAKE_BINARY_DIR}/${generated_path}/pm.yml)
-  list(APPEND header_files ${CMAKE_BINARY_DIR}/${generated_path}/pm_config.h)
+# Add subsys defined pm.yml to the input_files
+get_property(PM_SUBSYS_PREPROCESSED GLOBAL PROPERTY PM_SUBSYS_PREPROCESSED)
+list(APPEND input_files ${PM_SUBSYS_PREPROCESSED})
 
-  # Add subsys defined pm.yml to the input_files
-  list(APPEND input_files ${PM_SUBSYS_PREPROCESSED})
+if (DEFINED CONFIG_SOC_NRF9160)
+  # See nRF9160 Product Specification, chapter "UICR"
+  set(otp_start_addr "0xff8108")
+  set(otp_size 756) # 189 * 4
+elseif (DEFINED CONFIG_SOC_NRF5340_CPUAPP)
+  # See nRF5340 Product Specification, chapter Application Core -> ... "UICR"
+  set(otp_start_addr "0xff8100")
+  set(otp_size 764)  # 191 * 4
+endif()
 
-
-  if (DEFINED CONFIG_SOC_NRF9160)
-    # See nRF9160 Product Specification, chapter "UICR"
-    set(otp_start_addr "0xff8108")
-    set(otp_size 756) # 189 * 4
-  elseif (DEFINED CONFIG_SOC_NRF5340_CPUAPP)
-    # See nRF5340 Product Specification, chapter Application Core -> ... "UICR"
-    set(otp_start_addr "0xff8100")
-    set(otp_size 764)  # 191 * 4
-  endif()
-
-  math(EXPR flash_size "${CONFIG_FLASH_SIZE} * 1024" OUTPUT_FORMAT HEXADECIMAL)
-
-  if (CONFIG_SOC_NRF9160 OR CONFIG_SOC_NRF5340_CPUAPP)
-    add_region(
-      NAME otp
-      SIZE ${otp_size}
-      BASE ${otp_start_addr}
-      PLACEMENT start_to_end
-      )
-  endif()
+if (CONFIG_SOC_NRF9160 OR CONFIG_SOC_NRF5340_CPUAPP)
   add_region(
-    NAME flash_primary
-    SIZE ${flash_size}
-    BASE ${CONFIG_FLASH_BASE_ADDRESS}
-    PLACEMENT complex
-    DEVICE NRF_FLASH_DRV_NAME
-    )
-
-  if (CONFIG_PM_EXTERNAL_FLASH)
-    add_region(
-      NAME external_flash
-      SIZE ${CONFIG_PM_EXTERNAL_FLASH_SIZE}
-      BASE ${CONFIG_PM_EXTERNAL_FLASH_BASE}
-      PLACEMENT start_to_end
-      DEVICE ${CONFIG_PM_EXTERNAL_FLASH_DEV_NAME}
-      )
-  endif()
-
-  set(pm_cmd
-    ${PYTHON_EXECUTABLE}
-    ${NRF_DIR}/scripts/partition_manager.py
-    --input-files ${input_files}
-    --regions ${regions}
-    --output-partitions ${CMAKE_BINARY_DIR}/partitions.yml
-    --output-regions ${CMAKE_BINARY_DIR}/regions.yml
-    ${static_configuration}
-    ${region_arguments}
-    )
-
-  set(pm_output_cmd
-    ${PYTHON_EXECUTABLE}
-    ${NRF_DIR}/scripts/partition_manager_output.py
-    --input-partitions ${CMAKE_BINARY_DIR}/partitions.yml
-    --input-regions ${CMAKE_BINARY_DIR}/regions.yml
-    --config-file ${CMAKE_BINARY_DIR}/pm.config
-    --input-names ${images}
-    --header-files
-    ${header_files}
-    )
-
-  # Run the partition manager algorithm.
-  execute_process(
-    COMMAND
-    ${pm_cmd}
-    RESULT_VARIABLE ret
-    )
-
-  if(NOT ${ret} EQUAL "0")
-    message(FATAL_ERROR "Partition Manager failed, aborting. Command: ${pm_cmd}")
-  endif()
-
-  # Produce header files and config file.
-  execute_process(
-    COMMAND
-    ${pm_output_cmd}
-    RESULT_VARIABLE ret
-    )
-
-  if(NOT ${ret} EQUAL "0")
-    message(FATAL_ERROR "Partition Manager output generation failed, aborting. Command: ${pm_output_cmd}")
-  endif()
-
-  # Create a dummy target that we can add properties to for
-  # extraction in generator expressions.
-  add_custom_target(partition_manager)
-
-  # Make Partition Manager configuration available in CMake
-  import_kconfig(PM_ ${CMAKE_BINARY_DIR}/pm.config pm_var_names)
-
-  foreach(name ${pm_var_names})
-    set_property(
-      TARGET partition_manager
-      PROPERTY ${name}
-      ${${name}}
-      )
-  endforeach()
-
-  # Turn the space-separated list into a Cmake list.
-  string(REPLACE " " ";" PM_ALL_BY_SIZE ${PM_ALL_BY_SIZE})
-
-  # Iterate over every partition, from smallest to largest.
-  foreach(part ${PM_ALL_BY_SIZE})
-    string(TOUPPER ${part} PART)
-    get_property(${part}_PM_HEX_FILE GLOBAL PROPERTY ${part}_PM_HEX_FILE)
-    get_property(${part}_PM_ELF_FILE GLOBAL PROPERTY ${part}_PM_ELF_FILE)
-
-    # Process container partitions (if it has a SPAN list it is a container partition).
-    if(DEFINED PM_${PART}_SPAN)
-      string(REPLACE " " ";" PM_${PART}_SPAN ${PM_${PART}_SPAN})
-      list(APPEND containers ${part})
-    endif()
-
-    # Include the partition in the merge operation if it has a hex file.
-    if(DEFINED ${part}_PM_HEX_FILE)
-      get_property(${part}_PM_TARGET GLOBAL PROPERTY ${part}_PM_TARGET)
-      list(APPEND explicitly_assigned ${part})
-    else()
-      if(${part} IN_LIST images)
-        set(${part}_PM_HEX_FILE ${CMAKE_BINARY_DIR}/${part}/zephyr/${${part}_KERNEL_HEX_NAME})
-        set(${part}_PM_ELF_FILE ${CMAKE_BINARY_DIR}/${part}/zephyr/${${part}_KERNEL_ELF_NAME})
-        set(${part}_PM_TARGET ${part}_subimage)
-      elseif(${part} IN_LIST containers)
-        set(${part}_PM_HEX_FILE ${PROJECT_BINARY_DIR}/${part}.hex)
-        set(${part}_PM_TARGET ${part}_hex)
-      endif()
-      list(APPEND implicitly_assigned ${part})
-    endif()
-  endforeach()
-
-  set(PM_MERGED_SPAN ${implicitly_assigned} ${explicitly_assigned})
-  set(merged_overlap TRUE) # Enable overlapping for the merged hex file.
-
-  # Iterate over all container partitions, plus the "fake" merged paritition.
-  # The loop will create a hex file for each iteration.
-  foreach(container ${containers} merged)
-    string(TOUPPER ${container} CONTAINER)
-
-    # Prepare the list of hex files and list of dependencies for the merge command.
-    foreach(part ${PM_${CONTAINER}_SPAN})
-      string(TOUPPER ${part} PART)
-      list(APPEND ${container}hex_files ${${part}_PM_HEX_FILE})
-      list(APPEND ${container}elf_files ${${part}_PM_ELF_FILE})
-      list(APPEND ${container}targets ${${part}_PM_TARGET})
-    endforeach()
-
-    # If overlapping is enabled, add the appropriate argument.
-    if(${${container}_overlap})
-      set(${container}overlap_arg --overlap=replace)
-    endif()
-
-    # Add command to merge files.
-    add_custom_command(
-      OUTPUT ${PROJECT_BINARY_DIR}/${container}.hex
-      COMMAND
-      ${PYTHON_EXECUTABLE}
-      ${ZEPHYR_BASE}/scripts/mergehex.py
-      -o ${PROJECT_BINARY_DIR}/${container}.hex
-      ${${container}overlap_arg}
-      ${${container}hex_files}
-      DEPENDS
-      ${${container}targets}
-      ${${container}hex_files}
-      # SES will load symbols from all elf files listed as dependencies to ${PROJECT_BINARY_DIR}/merged.hex.
-      # Therefore we add ${${container}elf_files} as dependency to ensure they are loaded by SES even though
-      # it is unnecessary for building the application.
-      ${${container}elf_files}
-      )
-
-    # Wrapper target for the merge command.
-    add_custom_target(${container}_hex ALL DEPENDS ${PROJECT_BINARY_DIR}/${container}.hex)
-  endforeach()
-
-  # Add merged.hex as the representative hex file for flashing this app.
-  if(TARGET flash)
-    add_dependencies(flash merged_hex)
-  endif()
-  get_target_property(runners_content runner_yml_props_target yaml_contents)
-
-  string(REGEX REPLACE "--hex-file=[^\n]*"
-    "--hex-file=${PROJECT_BINARY_DIR}/merged.hex" new  ${runners_content})
-
-  set_property(
-    TARGET         runner_yml_props_target
-    PROPERTY       yaml_contents
-    ${new}
+    NAME otp
+    SIZE ${otp_size}
+    BASE ${otp_start_addr}
+    PLACEMENT start_to_end
     )
 endif()
+
+math(EXPR flash_size "${CONFIG_FLASH_SIZE} * 1024" OUTPUT_FORMAT HEXADECIMAL)
+
+add_region(
+  NAME flash_primary
+  SIZE ${flash_size}
+  BASE ${CONFIG_FLASH_BASE_ADDRESS}
+  PLACEMENT complex
+  DEVICE NRF_FLASH_DRV_NAME
+  )
+
+if (CONFIG_PM_EXTERNAL_FLASH)
+  add_region(
+    NAME external_flash
+    SIZE ${CONFIG_PM_EXTERNAL_FLASH_SIZE}
+    BASE ${CONFIG_PM_EXTERNAL_FLASH_BASE}
+    PLACEMENT start_to_end
+    DEVICE ${CONFIG_PM_EXTERNAL_FLASH_DEV_NAME}
+    )
+endif()
+
+set(pm_out_partition_files ${CMAKE_BINARY_DIR}/partitions_${domain}.yml)
+set(pm_out_region_files ${CMAKE_BINARY_DIR}/regions_${domain}.yml)
+set(pm_out_dotconf_files ${CMAKE_BINARY_DIR}/pm_${domain}.config)
+
+set(pm_cmd
+  ${PYTHON_EXECUTABLE}
+  ${NRF_DIR}/scripts/partition_manager.py
+  --input-files ${input_files}
+  --regions ${regions}
+  --output-partitions ${pm_out_partition_files}
+  --output-regions ${pm_out_region_files}
+  ${dynamic_partition_argument}
+  ${static_configuration}
+  ${region_arguments}
+  )
+
+set(pm_output_cmd
+  ${PYTHON_EXECUTABLE}
+  ${NRF_DIR}/scripts/partition_manager_output.py
+  --input-partitions ${pm_out_partition_files}
+  --input-regions ${pm_out_region_files}
+  --config-file ${pm_out_dotconf_files}
+  )
+
+# Run the partition manager algorithm.
+execute_process(
+  COMMAND
+  ${pm_cmd}
+  RESULT_VARIABLE ret
+  )
+
+if(NOT ${ret} EQUAL "0")
+  message(FATAL_ERROR "Partition Manager failed, aborting. Command: ${pm_cmd}")
+endif()
+
+# Produce header files and config file.
+execute_process(
+  COMMAND
+  ${pm_output_cmd}
+  RESULT_VARIABLE ret
+  )
+
+if(NOT ${ret} EQUAL "0")
+  message(FATAL_ERROR "Partition Manager output generation failed, aborting. Command: ${pm_output_cmd}")
+endif()
+
+# Create a dummy target that we can add properties to for
+# extraction in generator expressions.
+add_custom_target(partition_manager)
+
+# Make Partition Manager configuration available in CMake
+import_kconfig(PM_ ${pm_out_dotconf_files} pm_var_names)
+
+foreach(name ${pm_var_names})
+  set_property(
+    TARGET partition_manager
+    PROPERTY ${name}
+    ${${name}}
+    )
+endforeach()
+
+# Turn the space-separated list into a Cmake list.
+string(REPLACE " " ";" PM_ALL_BY_SIZE ${PM_ALL_BY_SIZE})
+
+# Iterate over every partition, from smallest to largest.
+foreach(part ${PM_ALL_BY_SIZE})
+  string(TOUPPER ${part} PART)
+  get_property(${part}_PM_HEX_FILE GLOBAL PROPERTY ${part}_PM_HEX_FILE)
+  get_property(${part}_PM_ELF_FILE GLOBAL PROPERTY ${part}_PM_ELF_FILE)
+
+  # Process container partitions (if it has a SPAN list it is a container partition).
+  if(DEFINED PM_${PART}_SPAN)
+    string(REPLACE " " ";" PM_${PART}_SPAN ${PM_${PART}_SPAN})
+    list(APPEND containers ${part})
+  endif()
+
+  # Include the partition in the merge operation if it has a hex file.
+  if(DEFINED ${part}_PM_HEX_FILE)
+    get_property(${part}_PM_TARGET GLOBAL PROPERTY ${part}_PM_TARGET)
+    list(APPEND explicitly_assigned ${part})
+  else()
+    if(${part} IN_LIST images)
+      set(${part}_PM_HEX_FILE ${CMAKE_BINARY_DIR}/${part}/zephyr/${${part}_KERNEL_HEX_NAME})
+      set(${part}_PM_ELF_FILE ${CMAKE_BINARY_DIR}/${part}/zephyr/${${part}_KERNEL_ELF_NAME})
+      set(${part}_PM_TARGET ${part}_subimage)
+    elseif(${part} IN_LIST containers)
+      set(${part}_PM_HEX_FILE ${PROJECT_BINARY_DIR}/${part}.hex)
+      set(${part}_PM_TARGET ${part}_hex)
+    endif()
+    list(APPEND implicitly_assigned ${part})
+  endif()
+endforeach()
+
+string(TOUPPER ${domain} DOMAIN)
+set(PM_MERGED_${DOMAIN}_SPAN ${implicitly_assigned} ${explicitly_assigned})
+set(merged_${domain}_overlap TRUE) # Enable overlapping for the merged hex file.
+
+# Iterate over all container partitions, plus the "fake" merged paritition.
+# The loop will create a hex file for each iteration.
+foreach(container ${containers} merged_${domain})
+  string(TOUPPER ${container} CONTAINER)
+
+  # Prepare the list of hex files and list of dependencies for the merge command.
+  foreach(part ${PM_${CONTAINER}_SPAN})
+    string(TOUPPER ${part} PART)
+    list(APPEND ${container}hex_files ${${part}_PM_HEX_FILE})
+    list(APPEND ${container}elf_files ${${part}_PM_ELF_FILE})
+    list(APPEND ${container}targets ${${part}_PM_TARGET})
+  endforeach()
+
+  # If overlapping is enabled, add the appropriate argument.
+  if(${${container}_overlap})
+    set(${container}overlap_arg --overlap=replace)
+  endif()
+
+  # Add command to merge files.
+  add_custom_command(
+    OUTPUT ${PROJECT_BINARY_DIR}/${container}.hex
+    COMMAND
+    ${PYTHON_EXECUTABLE}
+    ${ZEPHYR_BASE}/scripts/mergehex.py
+    -o ${PROJECT_BINARY_DIR}/${container}.hex
+    ${${container}overlap_arg}
+    ${${container}hex_files}
+    DEPENDS
+    ${${container}targets}
+    ${${container}hex_files}
+    # SES will load symbols from all elf files listed as dependencies to
+    # ${PROJECT_BINARY_DIR}/merged.hex. Therefore we add
+    # ${${container}elf_files} as dependency to ensure they are loaded by SES
+    # even though it is unnecessary for building the application.
+    ${${container}elf_files}
+    )
+
+  # Wrapper target for the merge command.
+  add_custom_target(
+    ${container}_hex
+    ALL DEPENDS
+    ${PROJECT_BINARY_DIR}/${container}.hex
+    )
+
+endforeach()
+
+get_target_property(runners_content runner_yml_props_target yaml_contents)
+
+string(REGEX REPLACE "--hex-file=[^\n]*"
+  "--hex-file=${PROJECT_BINARY_DIR}/merged_${domain}.hex" new  ${runners_content})
+
+set_property(
+  TARGET         runner_yml_props_target
+  PROPERTY       yaml_contents
+  ${new}
+  )
 
 if (CONFIG_SECURE_BOOT AND CONFIG_BOOTLOADER_MCUBOOT)
   # Create symbols for the offsets required for moving test update hex files
@@ -273,4 +334,98 @@ if (CONFIG_SECURE_BOOT AND CONFIG_BOOTLOADER_MCUBOOT)
     PROPERTY s1_TO_SECONDARY
     ${s1_offset}
     )
+endif()
+
+if (is_dynamic_partition_in_domain)
+  # We are being built as sub image.
+  # Expose the generated partition manager configuration files to parent image.
+  # This is used by the root image to create the global configuration in
+  # pm_config.h.
+  share("set(${domain}_PM_DOMAIN_PARTITIONS ${pm_out_partition_files})")
+  share("set(${domain}_PM_DOMAIN_REGIONS ${pm_out_region_files})")
+  share("set(${domain}_PM_DOMAIN_HEADER_FILES ${header_files})")
+  share("set(${domain}_PM_DOMAIN_IMAGES ${prefixed_images})")
+else()
+  # This is the root image, generate the global pm_config.h
+  # First, include the shared_vars.cmake file for all child images.
+  list(REMOVE_DUPLICATES PM_DOMAINS)
+  foreach (d ${PM_DOMAINS})
+    # Don't include shared vars from own domain.
+    if (NOT ${domain} STREQUAL ${d})
+      set(shared_vars_file
+        ${CMAKE_BINARY_DIR}/${${d}_PM_DOMAIN_DYNAMIC_PARTITION}/shared_vars.cmake
+        )
+      if (NOT (EXISTS ${shared_vars_file}))
+        message(FATAL_ERROR "Could not find shared vars file: ${shared_vars_file}")
+      endif()
+      include(${shared_vars_file})
+      list(APPEND header_files ${${d}_PM_DOMAIN_HEADER_FILES})
+      list(APPEND prefixed_images ${${d}_PM_DOMAIN_IMAGES})
+      list(APPEND pm_out_partition_files ${${d}_PM_DOMAIN_PARTITIONS})
+      list(APPEND pm_out_region_files ${${d}_PM_DOMAIN_REGIONS})
+      list(APPEND global_hex_depends ${${d}_PM_DOMAIN_DYNAMIC_PARTITION}_subimage)
+    endif()
+  endforeach()
+
+  # Explicitly add the root image domain hex file to the list
+  list(APPEND domain_hex_files ${PROJECT_BINARY_DIR}/merged_${domain}.hex)
+  list(APPEND global_hex_depends merged_${domain}_hex)
+
+  # Now all partition manager configuration from all images and domains are
+  # available. Generate the global pm_config.h, and provide it to all images.
+  set(pm_global_output_cmd
+    ${PYTHON_EXECUTABLE}
+    ${NRF_DIR}/scripts/partition_manager_output.py
+    --input-partitions ${pm_out_partition_files}
+    --input-regions ${pm_out_region_files}
+    --header-files ${header_files}
+    --images ${prefixed_images}
+    )
+
+  execute_process(
+    COMMAND
+    ${pm_global_output_cmd}
+    RESULT_VARIABLE ret
+    )
+
+  if(NOT ${ret} EQUAL "0")
+    message(FATAL_ERROR "Partition Manager GLOBAL output generation failed,
+    aborting. Command: ${pm_global_output_cmd}")
+  endif()
+
+  set_property(
+    TARGET partition_manager
+    PROPERTY PM_CONFIG_FILES
+    ${pm_out_partition_files}
+    )
+
+  set_property(
+    TARGET partition_manager
+    PROPERTY PM_DEPENDS
+    ${global_hex_depends}
+    )
+  # For convenience, generate global hex file containing all domains' hex files.
+  set(final_merged ${PROJECT_BINARY_DIR}/merged.hex)
+
+  # Add command to merge files.
+  add_custom_command(
+    OUTPUT ${final_merged}
+    COMMAND
+    ${PYTHON_EXECUTABLE}
+    ${ZEPHYR_BASE}/scripts/mergehex.py
+    -o ${final_merged}
+    ${domain_hex_files}
+    DEPENDS
+    ${global_hex_depends}
+    )
+
+  # Wrapper target for the merge command.
+  add_custom_target(merged_hex ALL DEPENDS ${final_merged})
+  # Add merged.hex as the representative hex file for flashing this app.
+  if(TARGET flash)
+    add_dependencies(flash merged_hex)
+  endif()
+  set(ZEPHYR_RUNNER_CONFIG_KERNEL_HEX "${final_merged}"
+    CACHE STRING "Path to merged image in Intel Hex format" FORCE)
+
 endif()

--- a/cmake/partition_manager.cmake
+++ b/cmake/partition_manager.cmake
@@ -59,6 +59,10 @@ endif()
 
 get_property(PM_IMAGES GLOBAL PROPERTY PM_IMAGES)
 
+# Create a dummy target that we can add properties to for
+# extraction in generator expressions.
+add_custom_target(partition_manager)
+
 # This file is executed once per domain.
 #
 # It will be executed if one of the following criteria is true for the
@@ -202,13 +206,11 @@ execute_process(
   RESULT_VARIABLE ret
   )
 
+set_property(TARGET partition_manager PROPERTY ENABLED True)
+
 if(NOT ${ret} EQUAL "0")
   message(FATAL_ERROR "Partition Manager output generation failed, aborting. Command: ${pm_output_cmd}")
 endif()
-
-# Create a dummy target that we can add properties to for
-# extraction in generator expressions.
-add_custom_target(partition_manager)
 
 # Make Partition Manager configuration available in CMake
 import_kconfig(PM_ ${pm_out_dotconf_files} pm_var_names)

--- a/cmake/reports.cmake
+++ b/cmake/reports.cmake
@@ -4,21 +4,18 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-set(pm_config
-  "$<$<TARGET_EXISTS:partition_manager>:$<TARGET_PROPERTY:partition_manager,PM_CONFIG_FILES>>")
-
-set(pm_depends
-  "$<<$<TARGET_EXISTS:partition_manager>:$<TARGET_PROPERTY:partition_manager,PM_DEPENDS>>")
-
 add_custom_target(
   partition_manager_report
   COMMAND
   ${PYTHON_EXECUTABLE}
+  # If partition manager does not exist, this line of code will cause python to
+  # simply print an empty line when running:
+  # ninja partition_manager_report
+  $<$<NOT:$<BOOL:$<TARGET_PROPERTY:partition_manager,ENABLED>>>:-cprint>
   ${ZEPHYR_BASE}/../nrf/scripts/partition_manager_report.py
-  --input ${pm_config}
-  "$<$<NOT:$<TARGET_EXISTS:partition_manager>>:--quiet>"
+  --input $<TARGET_PROPERTY:partition_manager,PM_CONFIG_FILES>
   DEPENDS
-  ${pm_depends}
+  $<TARGET_PROPERTY:partition_manager,PM_DEPENDS>
   )
 
 set_property(TARGET zephyr_property_target

--- a/cmake/reports.cmake
+++ b/cmake/reports.cmake
@@ -4,13 +4,21 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
+set(pm_config
+  "$<$<TARGET_EXISTS:partition_manager>:$<TARGET_PROPERTY:partition_manager,PM_CONFIG_FILES>>")
+
+set(pm_depends
+  "$<<$<TARGET_EXISTS:partition_manager>:$<TARGET_PROPERTY:partition_manager,PM_DEPENDS>>")
+
 add_custom_target(
   partition_manager_report
   COMMAND
   ${PYTHON_EXECUTABLE}
   ${ZEPHYR_BASE}/../nrf/scripts/partition_manager_report.py
-  --input ${CMAKE_BINARY_DIR}/partitions.yml
+  --input ${pm_config}
   "$<$<NOT:$<TARGET_EXISTS:partition_manager>>:--quiet>"
+  DEPENDS
+  ${pm_depends}
   )
 
 set_property(TARGET zephyr_property_target

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -21,3 +21,27 @@ endif()
 if (CONFIG_SECURE_BOOT)
   add_child_image(b0 ${CMAKE_CURRENT_LIST_DIR}/bootloader)
 endif ()
+
+# Special handling for the nRF53 when using RPMSG HCI.
+# Automatically include the hci_rpmsg sample as child image, and change
+# the board to be the network core.
+if (CONFIG_BT_RPMSG_NRF53)
+  if ((BOARD STREQUAL nrf5340_dk_nrf5340_cpuappns) OR
+      (BOARD STREQUAL nrf5340_dk_nrf5340_cpuapp))
+
+    set(hci_rpmsg_BOARD
+      nrf5340_dk_nrf5340_cpunet
+      )
+
+    set(${hci_rpmsg_BOARD}_PM_DOMAIN_DYNAMIC_PARTITION
+      hci_rpmsg
+      CACHE STRING "" FORCE
+      )
+
+  else()
+    message(FATAL_ERROR
+      "Board ${BOARD} not supported for including hci_rpmsg as child image")
+  endif()
+
+  create_domain_image(hci_rpmsg ${ZEPHYR_BASE}/samples/bluetooth/hci_rpmsg)
+endif()

--- a/scripts/partition_manager.py
+++ b/scripts/partition_manager.py
@@ -495,10 +495,11 @@ def load_reqs(input_config):
     return reqs
 
 
-def get_dynamic_area_start_and_size(static_config, flash_size):
+def get_dynamic_area_start_and_size(static_config, flash_size, dynamic_partition='app'):
     # Remove app from this dict to simplify the case where partitions before and after are removed.
     proper_partitions = [config for name, config in static_config.items()
-                         if 'span' not in config.keys() and name != 'app']
+                         if 'span' not in config.keys() and
+                         name != dynamic_partition]
 
     starts = {flash_size} | {config['address'] for config in proper_partitions}
     ends = {0} | {config['address'] + config['size'] for config in proper_partitions}
@@ -516,11 +517,15 @@ def get_region_config(pm_config, region_config, static_conf=None):
     placement_strategy = region_config['placement_strategy']
     region_name = region_config['name']
     device = region_config['device']
+    dynamic_partition = region_config['dynamic_partition'] \
+        if ('dynamic_partition' in region_config and region_config['dynamic_partition'] is not None)\
+        else 'app'
 
     if placement_strategy in [END_TO_START, START_TO_END]:
         solve_simple_region(pm_config, start, size, placement_strategy, region_name, device, static_conf)
     else:
-        solve_complex_region(pm_config, start, size, placement_strategy, region_name, device, static_conf)
+        solve_complex_region(pm_config, start, size, placement_strategy, region_name, device, static_conf,
+                             dynamic_partition)
 
 
 def solve_simple_region(pm_config, start, size, placement_strategy, region_name, device, static_conf):
@@ -568,6 +573,9 @@ def verify_static_conf(size, start, placement_strategy, static_conf):
     ends = {start} | {c['address'] + c['size'] for c in static_conf.values() if 'size' in c}
     gaps = list(zip(sorted(ends - starts), sorted(starts - ends)))
 
+    if len(gaps) == 0:
+        return  # All of the region is used, this is valid.
+
     if placement_strategy == START_TO_END:
         start_end_correct = gaps[0][0] == start + size
     else:
@@ -577,11 +585,12 @@ def verify_static_conf(size, start, placement_strategy, static_conf):
         raise RuntimeError("Statically defined partitions are not packed at the start/end of region")
 
 
-def solve_complex_region(pm_config, start, size, placement_strategy, region_name, device, static_conf):
+def solve_complex_region(pm_config, start, size, placement_strategy, region_name, device, static_conf,
+                         dynamic_partition):
     free_size = size
 
     if static_conf:
-        start, free_size = get_dynamic_area_start_and_size(static_conf, free_size)
+        start, free_size = get_dynamic_area_start_and_size(static_conf, free_size, dynamic_partition)
 
         # If nothing is unresolved (only app remaining), simply return the pre defined config with 'app'
         if len(pm_config) == 1:

--- a/scripts/partition_manager/partition_manager.rst
+++ b/scripts/partition_manager/partition_manager.rst
@@ -60,9 +60,9 @@ To add a Partition Manager configuration file for a subsystem, place the followi
 
   add_partition_manager_config(pm.yml)
 
-There are some limitations when multiple application images build the same subsystem code if it adds a Partition Manager configuration file in this way.
-In particular, partition definitions are global and must be identical across calls to ``add_partition_manager_config()``.
-If the same partition is defined twice with different configurations, the Partition Manager will fail.
+There are some limitations when multiple application images within the same domain build the same subsystem code if it adds a Partition Manager configuration file in this way.
+In particular, partition definitions are global per domain, and must be identical across calls to ``add_partition_manager_config()``.
+If the same partition is defined twice with different configurations within a domain, the Partition Manager will fail.
 
 .. _pm_yaml_format:
 

--- a/scripts/partition_manager_report.py
+++ b/scripts/partition_manager_report.py
@@ -8,10 +8,10 @@ import argparse
 import yaml
 import platform
 import sys
+from os import path
+
 
 def print_region(region, size, pm_config):
-    print("Partition Manager report")
-
     # Prepare colors (color code taken from size_report)
     bcolors_ansi = {
         "HEADER"    : '\033[95m',
@@ -30,7 +30,7 @@ def print_region(region, size, pm_config):
         bcolors = bcolors_ansi
 
     # Print header
-    print(bcolors["OKBLUE"] + "%s (0x%x):" % (region, size) + bcolors["ENDC"])
+    print(bcolors["OKBLUE"] + "%s (0x%x - %dkB):" % (region, size, size/1024) + bcolors["ENDC"])
 
     # Sort partitions three times:
     #  1. On whether they are a container (has a 'span'), containers first.
@@ -62,8 +62,8 @@ def parse_args():
     parser = argparse.ArgumentParser(
         description='Parse given Partition Manager output YAML file and print a pretty report',
         formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument("-i", "--input", required=True, type=str,
-                        help="Path to the YAML file from Partition Manager")
+    parser.add_argument("-i", "--input", required=True, type=str, nargs="*",
+                        help="Path to the domain specific YAML files from Partition Manager")
     parser.add_argument("-q", "--quiet", required=False, action='store_true',
                         help="Don't print anything")
 
@@ -77,11 +77,15 @@ def main():
 
     if args.quiet:
         sys.exit(0)
-    with open(args.input, 'r') as f:
-        pm_config = yaml.safe_load(f)
-    min_address = min((part['address'] for part in pm_config.values() if 'address' in part))
-    max_address = max((part['address'] + part['size'] for part in pm_config.values() if 'address' in part))
-    print_region('FLASH', max_address - min_address, pm_config)
+
+    for i in args.input:
+        fn = path.basename(i)
+        domain_name = fn[fn.index("partitions_") + len("partitions_"):fn.index(".yml")]
+        with open(i, 'r') as f:
+            pm_config_primary = {k: v for k, v in yaml.safe_load(f).items() if v['region'] == 'flash_primary'}
+        min_address = min((part['address'] for part in pm_config_primary.values() if 'address' in part))
+        max_address = max((part['address'] + part['size'] for part in pm_config_primary.values() if 'address' in part))
+        print_region(domain_name, max_address - min_address, pm_config_primary)
 
 
 if __name__ == "__main__":

--- a/scripts/partition_manager_report.py
+++ b/scripts/partition_manager_report.py
@@ -62,10 +62,8 @@ def parse_args():
     parser = argparse.ArgumentParser(
         description='Parse given Partition Manager output YAML file and print a pretty report',
         formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument("-i", "--input", required=True, type=str, nargs="*",
+    parser.add_argument("-i", "--input", required=True, type=str, nargs="+",
                         help="Path to the domain specific YAML files from Partition Manager")
-    parser.add_argument("-q", "--quiet", required=False, action='store_true',
-                        help="Don't print anything")
 
     args = parser.parse_args()
 
@@ -74,9 +72,6 @@ def parse_args():
 
 def main():
     args = parse_args()
-
-    if args.quiet:
-        sys.exit(0)
 
     for i in args.input:
         fn = path.basename(i)

--- a/west.yml
+++ b/west.yml
@@ -46,7 +46,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: fw-nrfconnect-zephyr
-      revision: c0e092a07d17820120f72b23a817dc895a5ca34e
+      revision: pull/287/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This commit refactor the calling of partition manager script by
removing the quiet argument and instead only call the script if
partition manager is enabled.

If partition manager is not enabled, then calling the
partition_manager_report will print:
Partition Manager is not enabled

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>