### PR TITLE
cmake: Update multi image variant build to load variant Kconfig root

### DIFF
--- a/cmake/multi_image.cmake
+++ b/cmake/multi_image.cmake
@@ -238,7 +238,17 @@ function(add_child_image_from_source)
       PROPERTY source_dir
       )
 
-    list(APPEND extra_cmake_args "-DCONFIG_NCS_IS_VARIANT_IMAGE=y")
+    # Create a variant specific Kconfig file to use.
+    # This allows for injecting additional Kconfig settings that should not be
+    # present for a regular image build.
+    if(EXISTS ${source_dir}/Kconfig)
+      set(BASE_IMAGE_KCONFIG_ROOT ${source_dir}/Kconfig)
+    else()
+      set(BASE_IMAGE_KCONFIG_ROOT ${ZEPHYR_BASE}/Kconfig)
+    endif()
+    set(VARIANT_KCONFIG_ROOT ${CMAKE_BINARY_DIR}/${ACI_NAME}/Kconfig.variant)
+    configure_file(${NRF_DIR}/subsys/bootloader/Kconfig.variant.template ${VARIANT_KCONFIG_ROOT})
+    list(APPEND extra_cmake_args "-DKCONFIG_ROOT=${VARIANT_KCONFIG_ROOT}")
   else()
     set(source_dir ${ACI_SOURCE_DIR})
 

--- a/samples/Kconfig
+++ b/samples/Kconfig
@@ -91,9 +91,6 @@ config LOG_DEFAULT_LEVEL
 
 endif # LOG
 
-config NCS_IS_VARIANT_IMAGE
-	bool "Image is a variant build of another image [READ ONLY]"
-
 config NCS_MCUBOOT_IN_BUILD
 	bool "MCUBoot is included in the build [READ ONLY]"
 	help

--- a/subsys/bootloader/Kconfig.variant.template
+++ b/subsys/bootloader/Kconfig.variant.template
@@ -1,0 +1,14 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+comment "${ACI_PRELOAD_IMAGE} variant build"
+
+config NCS_IS_VARIANT_IMAGE
+	bool
+	default y
+
+# Load the regular Kconfig root of the base image.
+source "${BASE_IMAGE_KCONFIG_ROOT}"


### PR DESCRIPTION
This commit allows NCS to configure a special Kconfig root for variant
builds.

This allows us to create Kconfig settings that should only be present
when constructing a variant build.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>